### PR TITLE
Align eligibility pathways with updated order

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,13 @@
  <!-- Financial eligibility -->
  <fieldset>
   <legend>Financial eligibility – cascaded routes</legend>
+  <ul>
+   <li>Pathway 1 – IMD 1‑2 postcode</li>
+   <li>Pathway 2 – Means‑tested benefits</li>
+   <li>Pathway 2 – ECO Flex Route 2</li>
+   <li>Pathway 3 – Income &lt; £36&nbsp;000</li>
+   <li>Pathway 3 – AHC Equalisation</li>
+  </ul>
   <!-- Pathway 1 IMD handled automatically -->
   <!-- Pathway 2 Means‑tested benefits -->
   <details>
@@ -90,31 +97,30 @@
    <label><input type="checkbox" class="benefit" value="UC"/> Universal Credit</label>
    <label><input type="checkbox" class="benefit" value="TC"/> Working / Child Tax Credit</label>
   </details>
-  <!-- Pathway 3 Gross income -->
+  <!-- Pathway 2 ECO Flex Route 2 -->
+  <details class="advFin hidden">
+   <summary>Pathway 2 – ECO Flex Route 2</summary>
+   <label><input type="checkbox" class="proxy" value="1"/> LSOA 1‑3</label>
+   <label><input type="checkbox" class="proxy" value="2"/> Council‑Tax Reduction</label>
+   <label><input type="checkbox" class="proxy" value="3"/> NICE NG6 vulnerability</label>
+   <label><input type="checkbox" class="proxy" value="4"/> Free School Meals</label>
+   <label><input type="checkbox" class="proxy" value="5"/> LA low‑income scheme</label>
+   <label><input type="checkbox" class="proxy" value="6"/> CA / supplier referral</label>
+   <label><input type="checkbox" class="proxy" value="7"/> Supplier debt data</label>
+  </details>
+  <!-- Pathway 3 Income threshold -->
   <details>
-   <summary>Pathway 3 – Gross income ≤ £36 000</summary>
+   <summary>Pathway 3 – Income &lt; £36&nbsp;000</summary>
    <label>Total gross household income (£) <input type="number" id="gross"/></label>
   </details>
-  <!-- Advanced routes hidden initially -->
-  <div id="advancedFin" class="hidden">
-   <details>
-    <summary>Pathway 4 – After‑housing‑cost equivalised</summary>
-    <label>Net income (£) <input type="number" id="net"/></label>
-    <label>Annual housing costs (£) <input type="number" id="housing"/></label>
-    <label>Adults in household <input type="number" id="adults" min="1" value="1"/></label>
-    <label>Children in household <input type="number" id="children" min="0" value="0"/></label>
-   </details>
-   <details>
-    <summary>Pathway 5 – ECO‑Flex two‑proxy</summary>
-    <label><input type="checkbox" class="proxy" value="1"/> LSOA 1‑3</label>
-    <label><input type="checkbox" class="proxy" value="2"/> Council‑Tax Reduction</label>
-    <label><input type="checkbox" class="proxy" value="3"/> NICE NG6 vulnerability</label>
-    <label><input type="checkbox" class="proxy" value="4"/> Free School Meals</label>
-    <label><input type="checkbox" class="proxy" value="5"/> LA low‑income scheme</label>
-    <label><input type="checkbox" class="proxy" value="6"/> CA / supplier referral</label>
-    <label><input type="checkbox" class="proxy" value="7"/> Supplier debt data</label>
-   </details>
-  </div>
+  <!-- Pathway 3 AHC Equalisation -->
+  <details class="advFin hidden">
+   <summary>Pathway 3 – AHC Equalisation</summary>
+   <label>Net income (£) <input type="number" id="net"/></label>
+   <label>Annual housing costs (£) <input type="number" id="housing"/></label>
+   <label>Adults in household <input type="number" id="adults" min="1" value="1"/></label>
+   <label>Children in household <input type="number" id="children" min="0" value="0"/></label>
+  </details>
  </fieldset>
 </details>
 <!-- Stage 3 docs -->

--- a/script.js
+++ b/script.js
@@ -29,7 +29,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     anyChecked(cls) { return [...document.querySelectorAll('.'+cls+':checked')].map(e => e.value); },
     show(el) { el.classList.remove('hidden'); },
     hide(el) { el.classList.add('hidden'); },
-    showAdvanced() { this.show($("advancedFin")); },
+    showAdvanced() {
+      document.querySelectorAll('.advFin').forEach(el => this.show(el));
+    },
     checkBorderline() {
       const sap = parseInt($("sap").value || 0);
       if (sap >= 60 && sap <= 68 && $("upgraded").checked) {
@@ -41,26 +43,29 @@ document.addEventListener('DOMContentLoaded', async () => {
     calculate() {
       const postcodeOk = this.postcodeMatch($("postcode").value);
       const benefitOk = this.anyChecked("benefit").length > 0;
+      const proxies = this.anyChecked("proxy");
       const gross = parseFloat($("gross").value || 0);
       const grossOk = gross > 0 && gross <= 36000;
       let pathway = "", finElig = false;
-      if (postcodeOk) { pathway = "1 IMD"; finElig = true; }
-      else if (benefitOk) { pathway = "2 benefits"; finElig = true; }
-      else if (grossOk) { pathway = "3 gross"; finElig = true; }
-      else {
+      if (postcodeOk) {
+        pathway = "1 IMD"; finElig = true;
+      } else if (benefitOk) {
+        pathway = "2 benefits"; finElig = true;
+      } else {
         this.showAdvanced();
-        const net = parseFloat($("net").value || 0);
-        const housing = parseFloat($("housing").value || 0);
-        const adults = parseInt($("adults").value);
-        const children = parseInt($("children").value);
-        const scale = 1 + 0.5 * (adults - 1) + 0.3 * children;
-        const ahc = (net - housing) / scale;
-        if (ahc > 0 && ahc < 14625) {
-          pathway = "4 AHC"; finElig = true;
+        if (proxies.length >= 2 && !((proxies.includes('5') || proxies.includes('6')) && proxies.includes('7'))) {
+          pathway = "2 ECO Flex"; finElig = true;
+        } else if (grossOk) {
+          pathway = "3 income"; finElig = true;
         } else {
-          const proxies = this.anyChecked("proxy");
-          if (proxies.length >= 2 && !((proxies.includes('5') || proxies.includes('6')) && proxies.includes('7'))) {
-            pathway = "5 ECO‑Flex"; finElig = true;
+          const net = parseFloat($("net").value || 0);
+          const housing = parseFloat($("housing").value || 0);
+          const adults = parseInt($("adults").value);
+          const children = parseInt($("children").value);
+          const scale = 1 + 0.5 * (adults - 1) + 0.3 * children;
+          const ahc = (net - housing) / scale;
+          if (ahc > 0 && ahc < 14625) {
+            pathway = "3 AHC"; finElig = true;
           }
         }
       }


### PR DESCRIPTION
## Summary
- list all possible financial pathways in the form
- reorder and rename the pathway sections
- adjust advanced field logic to show ECO Flex and AHC routes
- update eligibility calculation ordering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e41282e9c8321881238395beb99fe