### PR TITLE
Add pathway sections and show all satisfied routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,15 +78,10 @@
  <!-- Financial eligibility -->
  <fieldset>
   <legend>Financial eligibility – cascaded routes</legend>
-  <ul>
-   <li>Pathway 1 – IMD 1‑2 postcode</li>
-   <li>Pathway 2 – Means‑tested benefits</li>
-   <li>Pathway 2 – ECO Flex Route 2</li>
-   <li>Pathway 3 – Income &lt; £36&nbsp;000</li>
-   <li>Pathway 3 – AHC Equalisation</li>
-  </ul>
-  <!-- Pathway 1 IMD handled automatically -->
-  <!-- Pathway 2 Means‑tested benefits -->
+  <details>
+   <summary>Pathway 1 – IMD 1‑2 postcode</summary>
+   <p>This is checked automatically from the postcode.</p>
+  </details>
   <details>
    <summary>Pathway 2 – Means‑tested benefits</summary>
    <label><input type="checkbox" class="benefit" value="HB"/> Housing Benefit</label>
@@ -97,7 +92,6 @@
    <label><input type="checkbox" class="benefit" value="UC"/> Universal Credit</label>
    <label><input type="checkbox" class="benefit" value="TC"/> Working / Child Tax Credit</label>
   </details>
-  <!-- Pathway 2 ECO Flex Route 2 -->
   <details class="advFin hidden">
    <summary>Pathway 2 – ECO Flex Route 2</summary>
    <label><input type="checkbox" class="proxy" value="1"/> LSOA 1‑3</label>
@@ -108,12 +102,10 @@
    <label><input type="checkbox" class="proxy" value="6"/> CA / supplier referral</label>
    <label><input type="checkbox" class="proxy" value="7"/> Supplier debt data</label>
   </details>
-  <!-- Pathway 3 Income threshold -->
   <details>
    <summary>Pathway 3 – Income &lt; £36&nbsp;000</summary>
    <label>Total gross household income (£) <input type="number" id="gross"/></label>
   </details>
-  <!-- Pathway 3 AHC Equalisation -->
   <details class="advFin hidden">
    <summary>Pathway 3 – AHC Equalisation</summary>
    <label>Net income (£) <input type="number" id="net"/></label>

--- a/script.js
+++ b/script.js
@@ -46,6 +46,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       const proxies = this.anyChecked("proxy");
       const gross = parseFloat($("gross").value || 0);
       const grossOk = gross > 0 && gross <= 36000;
+      const possible = [];
+      if (postcodeOk) possible.push("Pathway 1 – IMD 1-2 postcode");
+      if (benefitOk) possible.push("Pathway 2 – Means-tested benefits");
+      const flexOk = proxies.length >= 2 && !((proxies.includes('5') || proxies.includes('6')) && proxies.includes('7'));
+      if (flexOk) possible.push("Pathway 2 – ECO Flex Route 2");
+      if (grossOk) possible.push("Pathway 3 – Income < £36,000");
+      const net = parseFloat($("net").value || 0);
+      const housing = parseFloat($("housing").value || 0);
+      const adults = parseInt($("adults").value);
+      const children = parseInt($("children").value);
+      const scale = 1 + 0.5 * (adults - 1) + 0.3 * children;
+      const ahc = (net - housing) / scale;
+      const ahcOk = ahc > 0 && ahc < 14625;
+      if (ahcOk) possible.push("Pathway 3 – AHC Equalisation");
       let pathway = "", finElig = false;
       if (postcodeOk) {
         pathway = "1 IMD"; finElig = true;
@@ -53,20 +67,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         pathway = "2 benefits"; finElig = true;
       } else {
         this.showAdvanced();
-        if (proxies.length >= 2 && !((proxies.includes('5') || proxies.includes('6')) && proxies.includes('7'))) {
+        if (flexOk) {
           pathway = "2 ECO Flex"; finElig = true;
         } else if (grossOk) {
           pathway = "3 income"; finElig = true;
-        } else {
-          const net = parseFloat($("net").value || 0);
-          const housing = parseFloat($("housing").value || 0);
-          const adults = parseInt($("adults").value);
-          const children = parseInt($("children").value);
-          const scale = 1 + 0.5 * (adults - 1) + 0.3 * children;
-          const ahc = (net - housing) / scale;
-          if (ahc > 0 && ahc < 14625) {
-            pathway = "3 AHC"; finElig = true;
-          }
+        } else if (ahcOk) {
+          pathway = "3 AHC"; finElig = true;
         }
       }
       let propElig = ["D","E","F","G"].includes($("epc").value) && parseInt($("sap").value || 0) < 70;
@@ -92,7 +98,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         this.hide($("docsSection"));
         this.hide($("measuresSection"));
       }
-      $("result").value = `Outcome: ${outcome}\nFinancial pathway: ${pathway}\nTenure: ${$("tenure").value}\nDocs by: ${$("docsBy").value || 'N/A'}`;
+      $("result").value = `Outcome: ${outcome}\nFinancial pathway: ${pathway}\nPossible pathways: ${possible.join(', ')}\nTenure: ${$("tenure").value}\nDocs by: ${$("docsBy").value || 'N/A'}`;
       const dump = {
         consent: [$("consentGen").checked, $("consentHealth").checked, $("consentShare").checked],
         call: $("callTime").value,


### PR DESCRIPTION
## Summary
- align financial eligibility details with bullet list
- compute every satisfied pathway during calculation
- show list of all matching pathways in the result

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_686e435677548321bd79bf352b88fe05