### PR TITLE
Change call time field to date

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <label><input type="checkbox" id="consentGen"/> Caller has read PEC privacy notice</label>
   <label><input type="checkbox" id="consentHealth"/> Caller consents to discuss health data</label>
   <label><input type="checkbox" id="consentShare"/> Caller consents for PEC to record & share health data with PCC</label>
-  <label>Call date & time <input type="datetime-local" id="callTime"/></label>
+  <label>Call date <input type="date" id="callTime"/></label>
   <label>Call attempt #
    <select id="attempt"><option>1</option><option>2</option><option>3</option></select>
   </label>

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
  h2{font-size:1.2rem;margin:1.5rem 0 .6rem}
  fieldset{border:1px solid #ccc;padding:1rem;margin-bottom:1rem}
  label{display:block;margin:.3rem 0}
- select,input[type="text"],input[type="number"],input[type="date"],input[type="datetime-local"]{width:100%;padding:.3rem}
+select,input[type="text"],input[type="number"],input[type="date"]{width:100%;padding:.3rem}
  summary{cursor:pointer;font-weight:bold}
  .hidden{display:none}
  textarea{width:100%;height:100px}


### PR DESCRIPTION
## Summary
- convert Call date & time field to date-only input
- remove unused CSS for datetime-local inputs

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_b_686e543f78f483219de1e1241a3eb147