### PR TITLE
Show IMD lookup results on separate lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,8 @@
  <!-- EPC / SAP -->
  <fieldset>
   <legend>Property EPC / SAP</legend>
-  <label>Postcode <input type="text" id="postcode" placeholder="e.g. PL5 2LD" /></label>
-  <p id="imdFlag">IMD eligibility: <strong>Unknown</strong></p>
-  <p id="imdDecile"></p>
-  <p id="imdIncomeDecile"></p>
+   <label>Postcode <input type="text" id="postcode" placeholder="e.g. PL5 2LD" /></label>
+   <p id="imdFlag">IMD eligibility: <strong>Unknown</strong></p>
   <label>EPC rating
    <select id="epc">
     <option value="">Select…</option><option>D</option><option>E</option><option>F</option><option>G</option><option value="Cplus">C‑or‑better</option>

--- a/script.js
+++ b/script.js
@@ -141,14 +141,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       $("postcode").addEventListener('input', () => {
         const value = $("postcode").value;
         const ok = this.postcodeMatch(value);
-        $("imdFlag").innerHTML = 'IMD eligibility: <strong>' + (ok ? 'Yes' : 'No') + '</strong>';
         const dec = this.getDeciles(value);
-        $("imdDecile").textContent = dec
-          ? 'Overall IMD decile: ' + dec.imdDecile
-          : '';
-        $("imdIncomeDecile").textContent = dec
-          ? 'Income IMD decile: ' + dec.incomeDecile
-          : '';
+        $("imdFlag").innerHTML =
+          'IMD eligibility: <strong>' + (ok ? 'Yes' : 'No') + '</strong>' +
+          (dec
+            ? '<br>Overall IMD decile: ' + dec.imdDecile +
+              '<br>Income IMD decile: ' + dec.incomeDecile
+            : '');
         if (dec && parseInt(dec.imdDecile, 10) >= 1 && parseInt(dec.imdDecile, 10) <= 3) {
           imdProxy.checked = true;
         } else {


### PR DESCRIPTION
## Summary
- remove unused decile elements from HTML
- combine IMD eligibility and decile info into a single element
- display postcode lookup information on separate lines

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_686e559f53dc8321a5e44a9d36854f3a