### PR TITLE
Move calculate button before Stage 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,8 @@
   </details>
  </fieldset>
 </details>
+<!-- Actions -->
+<button id="calcBtn">Calculate outcome</button>
 <!-- Stage 3 docs -->
 <details id="docsSection" class="hidden">
  <summary>Stage 3 – Documents the customer will send</summary>
@@ -150,9 +152,7 @@
   <label><input type="checkbox" class="measure" value="controls"/> Heating controls</label>
   <label><input type="checkbox" class="measure" value="vent"/> Ventilation upgrades</label>
  </fieldset>
-</details>
-<!-- Actions -->
-<button id="calcBtn">Calculate outcome</button>
+ </details>
 <!-- Results -->
 <details open>
  <summary>Outcome & CRM summary</summary>


### PR DESCRIPTION
## Summary
- move the **Calculate outcome** button to appear before Stage 3

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e577d29148321a8533868f7008eba