### PR TITLE
Add Stage 1 contact questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,44 @@
   <label>Call attempt #
    <select id="attempt"><option>1</option><option>2</option><option>3</option></select>
   </label>
+  <label>Why did you choose to get in touch with PEC?
+   <select id="whyContact">
+    <option value="">Select…</option>
+    <option>Free support</option>
+    <option>Improve home</option>
+    <option>Reduce environmental impact</option>
+    <option>Save on bills</option>
+    <option>Trusted advice and information</option>
+    <option>Warmer home</option>
+   </select>
+  </label>
+  <label>How did you hear about PEC?
+   <select id="heardVia">
+    <option value="">Select…</option>
+    <option>Business card in shop</option>
+    <option>Door knocking</option>
+    <option>Drop-in</option>
+    <option>Employer</option>
+    <option>Event</option>
+    <option>Facebook</option>
+    <option>Flyer through the door</option>
+    <option>Flyer/poster</option>
+    <option>Instagram</option>
+    <option>Letter in the post</option>
+    <option>LinkedIn</option>
+    <option>Print Media</option>
+    <option>Prior relationship with PEC</option>
+    <option>Radio</option>
+    <option>Signpost – Community organisation</option>
+    <option>Signpost – Charity</option>
+    <option>Signpost – Council</option>
+    <option>Signpost – Local business</option>
+    <option>Twitter</option>
+    <option>Web Search</option>
+    <option>Word of mouth</option>
+    <option>Other</option>
+   </select>
+  </label>
  </fieldset>
 </section>
 <!-- Stage 2 -->

--- a/script.js
+++ b/script.js
@@ -125,6 +125,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         consent: [$("consentGen").checked, $("consentHealth").checked, $("consentShare").checked],
         call: $("callTime").value,
         attempt: $("attempt").value,
+        whyContact: $("whyContact").value,
+        heardVia: $("heardVia").value,
         postcode: $("postcode").value,
         benefits: this.anyChecked("benefit"),
         gross: $("gross").value,


### PR DESCRIPTION
## Summary
- include new Stage 1 dropdowns for why callers contact PEC and how they heard
- capture answers in the debug dump

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_b_686e87cc11508321a729e2a3e6de4f72